### PR TITLE
Adding support for lifecycle nodes

### DIFF
--- a/nodl_to_policy/_common/lifecycle_node.xml
+++ b/nodl_to_policy/_common/lifecycle_node.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<profile xmlns:xi="http://www.w3.org/2003/XInclude">
+  <xi:include href="node.xml"
+    xpointer="xpointer(/profile/*)"/>
+  <services reply="ALLOW">
+    <service>~/change_state</service>
+    <service>~/get_available_states</service>
+    <service>~/get_available_transitions</service>
+    <service>~/get_state</service>
+    <service>~/get_transition_graph</service>
+  </services>
+  <topics publish="ALLOW">
+    <topic>~/transition_event</topic>
+  </topics>
+</profile>

--- a/nodl_to_policy/types.py
+++ b/nodl_to_policy/types.py
@@ -1,0 +1,21 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum, unique
+
+
+@unique
+class NodeType(Enum):
+    NODE = 'node'
+    LIFECYCLE_NODE = 'lifecycle_node'


### PR DESCRIPTION
This PR adds support for default permissions of lifecycle nodes. It's an extension to what exists in [`nodl_to_policy/_common/_profile.py`](https://github.com/osrf/nodl_to_policy/blob/d9b27c577c00b7e464fd843f19f787f1b3b3ce23/nodl_to_policy/_common/_profile.py#L24-L26), and can be formalized once discussion of lifecycle nodes in the NoDL design document (ros2/design#266) moves forward.

### Implementation considerations
Implementing support for lifecycle nodes will involve identifying whether a regular node or a lifecycle node's profile is required in `policy.convert_to_policy`, and then calling `_common._profile.common_profile` with the appropriate [Enum type](https://github.com/aprotyas/nodl_to_policy_osrf/blob/3745cb84968690bdfc76d49ffb2c24538c1b278b/nodl_to_policy/types.py#L18-L21).

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>