### PR TITLE
Change default enclave paths from `"/"` to `"/<node_name>"`

### DIFF
--- a/nodl_to_policy/policy.py
+++ b/nodl_to_policy/policy.py
@@ -65,11 +65,13 @@ def get_profile(policy: etree._ElementTree, node_name: str) -> etree._ElementTre
     :return: LXML ElementTree structure representing a "profile" tag.
     :rtype: etree._ElementTree
     """
-    enclave = policy.find(path=f'enclaves/enclave[@path="/"]')
+    # Every node is assumed to be in its own enclave
+    # This assumption is needed since the NoDL description does not specify enclave paths
+    # Moreover, this assumption is better than placing all nodes in the base "/" path
+    enclave = policy.find(path=f'enclaves/enclave[@path="/{node_name}"]')
     if enclave is None:
         enclave = etree.Element('enclave')
-        # unqualified enclave path for now, refer to security enclaves design article
-        enclave.attrib['path'] = '/'
+        enclave.attrib['path'] = f'/{node_name}'
         profiles = etree.Element('profiles')
         enclave.append(profiles)
         enclaves = policy.find('enclaves')

--- a/test/nodl_to_policy/fixtures/test.policy.xml
+++ b/test/nodl_to_policy/fixtures/test.policy.xml
@@ -1,6 +1,6 @@
 <policy version="0.2.0">
   <enclaves>
-    <enclave path="/">
+    <enclave path="/node_1">
       <profiles>
         <profile node="node_1" ns="/">
           <services reply="ALLOW">
@@ -29,6 +29,10 @@
             <topic>rosout</topic>
           </topics>
         </profile>
+      </profiles>
+    </enclave>
+    <enclave path="/node_2">
+      <profiles>
         <profile node="node_2" ns="/">
           <actions execute="ALLOW">
             <action>example_action</action>

--- a/test/nodl_to_policy/test_policy.py
+++ b/test/nodl_to_policy/test_policy.py
@@ -42,7 +42,7 @@ def test_get_profile_minimal():
     # check that a single enclave tag was created
     assert len(test_enclaves) == 1
     assert test_enclave.tag == 'enclave'
-    assert test_enclave.attrib['path'] == '/'
+    assert test_enclave.attrib['path'] == '/foo'
 
     # check that a single profiles tag was created
     assert len(test_enclave) == 1
@@ -66,24 +66,24 @@ def test_get_profile_exists(test_policy_tree):
     """
     test_policy = test_policy_tree
     test_enclaves = test_policy.find(path='enclaves')
-    test_enclave = test_enclaves.find(path=f'enclave[@path="/"]')
+    test_enclave = test_enclaves.find(path=f'enclave[@path="/node_1"]')
     test_profiles = test_enclave.find(path='profiles')
     test_profile = policy.get_profile(test_policy, node_name='node_1')
 
     # check that a single enclaves tag exists
     assert test_policy[0] == test_enclaves
-    assert len(test_enclaves) == 1  # check that 'enclaves' tree contains one child ('enclave')
+    assert len(test_enclaves) == 2  # check that 'enclaves' tree contains two children
     assert test_enclaves.tag == 'enclaves'
 
     # check that a single enclave tag exists
     assert test_enclaves[0] == test_enclave
     assert len(test_enclave) == 1  # check that 'enclave' tree contains one child ('profiles')
     assert test_enclave.tag == 'enclave'
-    assert test_enclave.attrib['path'] == '/'
+    assert test_enclave.attrib['path'] == '/node_1'
 
     # check that a single profiles tag exists
     assert test_enclave[0] == test_profiles
-    assert len(test_profiles) == 2  # two nodes, one profile tag for each
+    assert len(test_profiles) == 1  # two nodes, one profile tag for each
     assert test_profiles.tag == 'profiles'
 
     # check that a <profile node='node1'> tag exists as expected
@@ -118,7 +118,7 @@ def test_get_permissions_exists(test_policy_tree):
     `get_profile` function does not alter an existing policy tree.
     """
     test_profile = test_policy_tree.find(
-        path='enclaves/enclave[@path="/"]/profiles/profile[@ns="/"][@node="node_1"]')
+        path='enclaves/enclave[@path="/node_1"]/profiles/profile[@ns="/"][@node="node_1"]')
     test_permissions = policy.get_permissions(
         profile=test_profile,
         permission_type='topic',
@@ -171,7 +171,7 @@ def test_add_permissions_minimal():
 def test_add_permissions_exists(test_policy_tree):
     """Test a profile tree with pre-existing permissions."""
     test_profile = test_policy_tree.find(
-        path='enclaves/enclave[@path="/"]/profiles/profile[@ns="/"][@node="node_1"]')
+        path='enclaves/enclave[@path="/node_1"]/profiles/profile[@ns="/"][@node="node_1"]')
 
     policy.add_permissions(
         profile=test_profile,
@@ -202,14 +202,14 @@ def test_add_common_permissions_minimal(helpers, common_profile_tree):
 def test_add_common_permissions_exists(helpers, test_policy_tree):
     """Test addition of common permissions to a profile tree with pre-existing permission tags."""
     test_profile = test_policy_tree.find(
-        path='enclaves/enclave[@path="/"]/profiles/profile[@ns="/"][@node="node_1"]')
+        path='enclaves/enclave[@path="/node_1"]/profiles/profile[@ns="/"][@node="node_1"]')
     policy.add_common_permissions(
         test_profile, node=nodl.types.Node(name='node', executable='prog'))
 
     assert helpers.xml_trees_equal(
         test_profile,
         test_policy_tree.find(
-            path='enclaves/enclave[@path="/"]/profiles/profile[@ns="/"][@node="node_1"]')
+            path='enclaves/enclave[@path="/node_1"]/profiles/profile[@ns="/"][@node="node_1"]')
     )
 
 

--- a/test/nodl_to_policy/test_policy.py
+++ b/test/nodl_to_policy/test_policy.py
@@ -83,7 +83,7 @@ def test_get_profile_exists(test_policy_tree):
 
     # check that a single profiles tag exists
     assert test_enclave[0] == test_profiles
-    assert len(test_profiles) == 1  # two nodes, one profile tag for each
+    assert len(test_profiles) == 1  # one node per enclave, one profile tag for each
     assert test_profiles.tag == 'profiles'
 
     # check that a <profile node='node1'> tag exists as expected


### PR DESCRIPTION
This PR changes the way enclave paths are generated for each node. It makes the assumption that each node is under its own enclave, named according to the node name. This is a better assumption than bunching all nodes under the default `"/"` enclave path, and also more aligned with how the `sros2` and `ros2launch_security` packages reason about enclaves.

Additionally, I patched the tests and the test fixtures to reflect this change in enclave paths.

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>