### PR TITLE
Adding CI (GitHub actions) for `nodl_to_policy`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+omit =
+    # omit test directory
+    test/*
+    setup.py
+branch=True

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,54 @@
+name: Test nodl_to_policy
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  # ros-tooling/setup-ros reports missing `colcon` with
+  # actions/checkout, so using a docker based build solution for now
+  docker-build-and-test:
+    runs-on: ubuntu-20.04
+    container:
+      image: ros:galactic
+    steps:
+      - name: Preparation
+        run: |
+          apt-get -qq update
+          apt-get -qq upgrade -y
+          apt-get install curl -y
+          colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/1ddb69bedfd1f04c2f000e95452f7c24a4d6176b/index.yaml
+          colcon mixin update default
+          mkdir -p src
+
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+        with:
+          path: src/
+
+      - run: cp src/codecov.yml .
+
+      - name: Install dependencies
+        run: DEBIAN_FRONTEND=noninteractive rosdep update && rosdep install --from-paths src --ignore-src --rosdistro galactic -y
+
+      - name: Build package
+        run: . /opt/ros/$ROS_DISTRO/setup.sh && colcon build --event-handlers console_cohesion+ --mixin coverage-pytest --packages-select nodl_to_policy --merge-install
+
+      - name: Run tests
+        id: action_ros_ci_step
+        run: . /opt/ros/$ROS_DISTRO/setup.sh && colcon test --merge-install --mixin coverage-pytest --packages-select nodl_to_policy --return-code-on-test-failure --event-handlers console_cohesion+
+
+      - name: Codecov
+        uses: codecov/codecov-action@v1.5.2
+        with:
+          file: build/nodl_to_policy/coverage.xml
+          fail_ci_if_error: true
+          flags: nodl_to_policy
+          name: codecov-nodl_to_policy
+
+      - name: Upload Logs
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: colcon-logs-linux
+          path: log/
+        if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,54 +1,59 @@
-name: Test nodl_to_policy
+name: nodl_to_policy
 
 on:
   pull_request:
   push:
+    branches:
+      - master
 
 jobs:
-  # ros-tooling/setup-ros reports missing `colcon` with
-  # actions/checkout, so using a docker based build solution for now
-  docker-build-and-test:
-    runs-on: ubuntu-20.04
-    container:
-      image: ros:galactic
+  build-and-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-20.04
+        ros_distribution:
+          - galactic
     steps:
-      - name: Preparation
-        run: |
-          apt-get -qq update
-          apt-get -qq upgrade -y
-          apt-get install curl -y
-          colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/1ddb69bedfd1f04c2f000e95452f7c24a4d6176b/index.yaml
-          colcon mixin update default
-          mkdir -p src
-
-      - name: Checkout
-        uses: actions/checkout@v2
+      # actions/checkout is not used because of a known issue where `colcon` cannot be found
+      # https://github.com/ros-tooling/setup-ros/issues/75
+      - name: Setup ROS2
+        uses: ros-tooling/setup-ros@v0.2
         with:
-          path: src/
+          use-ros2-testing: true
+          required-ros-distributions: ${{ matrix.ros_distribution }}
 
-      - run: cp src/codecov.yml .
+      - name: Test nodl_to_policy
+        uses: ros-tooling/action-ros-ci@v0.2
+        id: action_ros_ci
+        with:
+          package-name: nodl_to_policy
+          colcon-defaults: |
+            {
+              "test": {
+                "mixin": ["coverage-pytest"]
+              }
+            }
+          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/1ddb69bedfd1f04c2f000e95452f7c24a4d6176b/index.yaml
+          target-ros2-distro: ${{ matrix.ros_distribution }}
 
-      - name: Install dependencies
-        run: DEBIAN_FRONTEND=noninteractive rosdep update && rosdep install --from-paths src --ignore-src --rosdistro galactic -y
+      # `outputs.root_dir` is set to the relative path of the checked out git repository
+      - name: Find project root
+        id: find_project
+        run: echo "::set-output name=root_dir::$(vcs diff -s --repos . | cut -d ' ' -f 1)"
 
-      - name: Build package
-        run: . /opt/ros/$ROS_DISTRO/setup.sh && colcon build --event-handlers console_cohesion+ --mixin coverage-pytest --packages-select nodl_to_policy --merge-install
-
-      - name: Run tests
-        id: action_ros_ci_step
-        run: . /opt/ros/$ROS_DISTRO/setup.sh && colcon test --merge-install --mixin coverage-pytest --packages-select nodl_to_policy --return-code-on-test-failure --event-handlers console_cohesion+
-
-      - name: Codecov
+      - name: Codecov report
         uses: codecov/codecov-action@v1
         with:
-          file: build/nodl_to_policy/coverage.xml
+          files: ${{ steps.action_ros_ci.outputs.ros-workspace-directory-name }}/build/nodl_to_policy/coverage.xml
+          root_dir: ${{ steps.find_project.outputs.root_dir }}  # `codecov.yml` file found here
           fail_ci_if_error: true
-          flags: nodl_to_policy
           name: codecov-nodl_to_policy
 
       - name: Upload Logs
         uses: actions/upload-artifact@v2
         with:
-          name: colcon-logs-linux
-          path: log/
+          name: colcon_logs
+          path: ${{ steps.action_ros_ci.outputs.ros-workspace-directory-name }}/log
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           mkdir -p src
 
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2
         with:
           path: src/
 
@@ -39,7 +39,7 @@ jobs:
         run: . /opt/ros/$ROS_DISTRO/setup.sh && colcon test --merge-install --mixin coverage-pytest --packages-select nodl_to_policy --return-code-on-test-failure --event-handlers console_cohesion+
 
       - name: Codecov
-        uses: codecov/codecov-action@v1.5.2
+        uses: codecov/codecov-action@v1
         with:
           file: build/nodl_to_policy/coverage.xml
           fail_ci_if_error: true
@@ -47,7 +47,7 @@ jobs:
           name: codecov-nodl_to_policy
 
       - name: Upload Logs
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v2
         with:
           name: colcon-logs-linux
           path: log/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,19 +38,6 @@ jobs:
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/1ddb69bedfd1f04c2f000e95452f7c24a4d6176b/index.yaml
           target-ros2-distro: ${{ matrix.ros_distribution }}
 
-      # `outputs.root_dir` is set to the relative path of the checked out git repository
-      - name: Find project root
-        id: find_project
-        run: echo "::set-output name=root_dir::$(vcs diff -s --repos . | cut -d ' ' -f 1)"
-
-      - name: Codecov report
-        uses: codecov/codecov-action@v1
-        with:
-          files: ${{ steps.action_ros_ci.outputs.ros-workspace-directory-name }}/build/nodl_to_policy/coverage.xml
-          root_dir: ${{ steps.find_project.outputs.root_dir }}  # `codecov.yml` file found here
-          fail_ci_if_error: true
-          name: codecov-nodl_to_policy
-
       - name: Upload Logs
         uses: actions/upload-artifact@v2
         with:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # nodl_to_policy
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Build status](https://github.com/osrf/nodl_to_policy/actions/workflows/test.yml/badge.svg)](https://github.com/osrf/nodl_to_policy/actions/workflows/test.yml)
 
 This repository contains tooling to generate a [ROS 2 Access Control Policy](https://design.ros2.org/articles/ros2_access_control_policies.html) from the [Node Interface Definition Language (NoDL)](https://github.com/ros2/design/pull/266) description of a ROS system (or that of a specific package), primarily to be used in conjunction with the `SROS2` utilities.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Build status](https://github.com/osrf/nodl_to_policy/actions/workflows/test.yml/badge.svg)](https://github.com/osrf/nodl_to_policy/actions/workflows/test.yml)
-[![Code coverage](https://codecov.io/gh/osrf/nodl_to_policy/branch/master/graph/badge.svg)](https://codecov.io/gh/osrf/nodl_to_policy)
 
 This repository contains tooling to generate a [ROS 2 Access Control Policy](https://design.ros2.org/articles/ros2_access_control_policies.html) from the [Node Interface Definition Language (NoDL)](https://github.com/ros2/design/pull/266) description of a ROS system (or that of a specific package), primarily to be used in conjunction with the `SROS2` utilities.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Build status](https://github.com/osrf/nodl_to_policy/actions/workflows/test.yml/badge.svg)](https://github.com/osrf/nodl_to_policy/actions/workflows/test.yml)
+[![Code coverage](https://codecov.io/gh/osrf/nodl_to_policy/branch/master/graph/badge.svg)](https://codecov.io/gh/osrf/nodl_to_policy)
 
 This repository contains tooling to generate a [ROS 2 Access Control Policy](https://design.ros2.org/articles/ros2_access_control_policies.html) from the [Node Interface Definition Language (NoDL)](https://github.com/ros2/design/pull/266) description of a ROS system (or that of a specific package), primarily to be used in conjunction with the `SROS2` utilities.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,15 +1,2 @@
 fixes:
-  - "src/::"
-coverage:
-  status:
-    project:
-      default:
-        flags:
-          - nodl_to_policy
-      nodl_to_policy:
-        flags:
-          - nodl_to_policy
-flags:
-  nodl_to_policy:
-    paths:
-      - nodl_to_policy
+  - "ros_ws/src/*/nodl_to_policy/::"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,0 @@
-fixes:
-  - "ros_ws/src/*/nodl_to_policy/::"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+fixes:
+  - "src/::"
+coverage:
+  status:
+    project:
+      default:
+        flags:
+          - nodl_to_policy
+      nodl_to_policy:
+        flags:
+          - nodl_to_policy
+flags:
+  nodl_to_policy:
+    paths:
+      - nodl_to_policy


### PR DESCRIPTION
This PR introduces a preliminary workflow file that triggers tests and code coverage for `nodl_to_policy` on every push/PR.

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>