### PR TITLE
fix flake8 warnings about unnecessary list comprehensions

### DIFF
--- a/nodl_to_policy/policy.py
+++ b/nodl_to_policy/policy.py
@@ -148,7 +148,7 @@ def add_permissions(
             permission.text = expression_name[len('/'):]
         else:
             permission.text = expression_name
-        if permission.text in [expression.text for expression in permissions]:
+        if permission.text in (expression.text for expression in permissions):
             continue
         permissions.append(permission)
 

--- a/test/nodl_to_policy/_common/test__profile.py
+++ b/test/nodl_to_policy/_common/test__profile.py
@@ -114,16 +114,16 @@ def test__get_profile(common_profile_tree):
 
     assert len(test_pub_topics) == len(pub_topics)
     print(test_pub_topics)
-    assert all([pub_topic in test_pub_topics for pub_topic in pub_topics])
+    assert all(pub_topic in test_pub_topics for pub_topic in pub_topics)
 
     assert len(test_sub_topics) == len(sub_topics)
-    assert all([sub_topic in test_sub_topics for sub_topic in sub_topics])
+    assert all(sub_topic in test_sub_topics for sub_topic in sub_topics)
 
     assert len(test_reply_services) == len(services)
-    assert all([service in test_reply_services for service in services])
+    assert all(service in test_reply_services for service in services)
 
     assert len(test_request_services) == len(services)
-    assert all([service in test_request_services for service in services])
+    assert all(service in test_request_services for service in services)
 
 
 def test__get_items_by_role_empty_request():

--- a/test/nodl_to_policy/test_policy.py
+++ b/test/nodl_to_policy/test_policy.py
@@ -185,7 +185,7 @@ def test_add_permissions_exists(test_policy_tree):
     assert test_permissions.attrib['publish'] == 'ALLOW'
     assert len(test_permissions) == 4
     test_permission_items = test_permissions.findall(path='topic')
-    assert 'item' in [item.text for item in test_permission_items]
+    assert 'item' in (item.text for item in test_permission_items)
 
 
 def test_add_common_permissions_minimal(helpers, common_profile_tree):


### PR DESCRIPTION
I don't feel like this is a great warning, but I fixed it anyway.

Again @aprotyas I can't add you as a reviewer but FYI.

These were the errors:

```
----------------------------- Captured stdout call -----------------------------

./test/nodl_to_policy/test_policy.py:188:12: C412 Unnecessary list comprehension - 'in' can take a generator.
    assert 'item' in [item.text for item in test_permission_items]
           ^

./test/nodl_to_policy/_common/test__profile.py:117:12: C407 Unnecessary list comprehension - 'all' can take a generator.
    assert all([pub_topic in test_pub_topics for pub_topic in pub_topics])
           ^

./test/nodl_to_policy/_common/test__profile.py:120:12: C407 Unnecessary list comprehension - 'all' can take a generator.
    assert all([sub_topic in test_sub_topics for sub_topic in sub_topics])
           ^

./test/nodl_to_policy/_common/test__profile.py:123:12: C407 Unnecessary list comprehension - 'all' can take a generator.
    assert all([service in test_reply_services for service in services])
           ^

./test/nodl_to_policy/_common/test__profile.py:126:12: C407 Unnecessary list comprehension - 'all' can take a generator.
    assert all([service in test_request_services for service in services])
           ^

./nodl_to_policy/policy.py:151:12: C412 Unnecessary list comprehension - 'in' can take a generator.
        if permission.text in [expression.text for expression in permissions]:
           ^

4     C407 Unnecessary list comprehension - 'all' can take a generator.
2     C412 Unnecessary list comprehension - 'in' can take a generator.

19 files checked
6 errors
```